### PR TITLE
Add skip if commit contains parameter

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,11 +3,11 @@ name: 'Bump Version Plus'
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   bump-version:
-    name: 'Bump version on master'
+    name: 'Bump version on main'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,11 +3,11 @@ name: 'Bump Version Plus'
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
 
 jobs:
   bump-version:
-    name: 'Bump version on main'
+    name: 'Bump version on master'
     runs-on: ubuntu-latest
 
     steps:
@@ -24,6 +24,8 @@ jobs:
           tag-prefix: 'v'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'cat package.json'
+        run: cat ./package.json
       - name: 'Output Step'
         env:
           NEW_TAG: ${{ steps.version-bump.outputs.newTag }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,9 +17,9 @@ jobs:
           ref: ${{ github.ref }}
       - name: 'cat package.json'
         run: cat ./package.json
-      - name: 'Automated Version Bump'
+      - name: Automated Version Bump Plus
+        uses: 'mhillerstrom/gh-action-bump-version-plus@v2.0.3'
         id: version-bump
-        uses: 'mhillerstrom/gh-action-bump-version-plus@master'
         with:
           tag-prefix: 'v'
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,8 +24,6 @@ jobs:
           tag-prefix: 'v'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'cat package.json'
-        run: cat ./package.json
       - name: 'Output Step'
         env:
           NEW_TAG: ${{ steps.version-bump.outputs.newTag }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ GitHub Action for automated npm version bump.
 
 > As the `plus` indicates this action will do all what `gh-action-bump-version`
 > does plus some handling of Lerna mono repos. For Lerna mono repos we
-> __always__ bump all packages in the mono repo.
+> ___always___ bump all packages in the mono repo.
+>
+> Additionally, we introduce a parameter `skip-if-commit-contains` (see below).
 
 This Action bumps the version in `package.json` and pushes it back to the repo. It
 is meant to be used on every successful merge to master but you'll need to
@@ -57,8 +59,8 @@ Remove the 'actions/setup-node@v1' step from your action.yml file
 **tag-prefix:** Prefix that is used for the git tag  (optional). Example:
 
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+- name:  'Automated Version Bump Plus'
+  uses:  'mhillerstrom/gh-action-bump-version-plus@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -68,8 +70,8 @@ Remove the 'actions/setup-node@v1' step from your action.yml file
 **skip-tag:** The tag is not added to the git repository  (optional). Example:
 
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+- name:  'Automated Version Bump Plus'
+  uses:  'mhillerstrom/gh-action-bump-version-plus@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -80,8 +82,8 @@ Remove the 'actions/setup-node@v1' step from your action.yml file
 Example:
 
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+- name:  'Automated Version Bump Plus'
+  uses:  'mhillerstrom/gh-action-bump-version-plus@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -92,8 +94,8 @@ Example:
 defaults to 'rc'). Example:
 
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+- name:  'Automated Version Bump Plus'
+  uses:  'mhillerstrom/gh-action-bump-version-plus@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -105,8 +107,8 @@ defaults to 'rc'). Example:
 string, case sensitive, coma separated  (optional). Example:
 
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+- name:  'Automated Version Bump Plus'
+  uses:  'mhillerstrom/gh-action-bump-version-plus@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -121,8 +123,8 @@ string, case sensitive, coma separated  (optional). Example:
 (optional). Example:
 
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+- name:  'Automated Version Bump Plus'
+  uses:  'mhillerstrom/gh-action-bump-version-plus@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     PACKAGEJSON_DIR:  'frontend'
@@ -133,8 +135,8 @@ Useful in cases such as updating the version on master after a tag has been set
 (optional). Example:
 
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+- name:  'Automated Version Bump Plus'
+  uses:  'mhillerstrom/gh-action-bump-version-plus@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -145,8 +147,8 @@ Useful in cases such as updating the version on master after a tag has been set
 for skipping additional workflows run on push. Example:
 
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+- name:  'Automated Version Bump Plus'
+  uses:  'mhillerstrom/gh-action-bump-version-plus@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
@@ -157,12 +159,25 @@ for skipping additional workflows run on push. Example:
 Example:
 
 ```yaml
-- name:  'Automated Version Bump'
-  uses:  'phips28/gh-action-bump-version@master'
+- name:  'Automated Version Bump Plus'
+  uses:  'mhillerstrom/gh-action-bump-version-plus@master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
     push: false
+```
+
+
+**skip-if-commit-contains:** Skip Version Bump Plus if the commit message contains the specified (case-insensitive) string
+Example:
+
+```yaml
+- name:  'Automated Version Bump Plus'
+  uses:  'mhillerstrom/gh-action-bump-version-plus@master'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    skip-if-commit-contains: dependabot
 ```
 
 ### Testing

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: 'Set to false to skip pushing the new tag'
     default: 'true'
     required: false
+  skip-if-commit-contains:
+    description: 'Skip Version Bump Plus action if commit message contains text specified'
+    default: ''
+    required: false
 outputs:
   newTag:
     description: 'The newly created tag'

--- a/index.js
+++ b/index.js
@@ -31,6 +31,16 @@ const workspace = process.env.GITHUB_WORKSPACE;
 
   const tagPrefix = process.env['INPUT_TAG-PREFIX'] || '';
   const messages = event.commits ? event.commits.map((commit) => `${commit.message}\n${commit.body}`) : [];
+  
+  // Should we bail-out because of a text in commit message?
+  const checkMessage = process.env['INPUT_SKIP-IF-COMMIT-CONTAINS'].toLowerCase();
+  if (checkMessage != '') {
+    const messagesString = messages.join(',').toLowerCase();
+    if (messagesString.indexOf(checkMessage) > -1) {
+      exitSuccess(`No action necessary because we found '${checkMessage}' in commit message!`);
+      return;
+    }
+  }
 
   const commitMessage = process.env['INPUT_COMMIT-MESSAGE'] || 'ci: version bump to {{version}}';
   console.log('commit messages:', messages);

--- a/tests/end-to-end/config.yaml
+++ b/tests/end-to-end/config.yaml
@@ -93,6 +93,53 @@ setups:
       - message: custom-pre
         expected:
           version: 1.0.1-pre.0
+  - name: skip-if-commit-contains
+    yaml:
+      name: Bump Version (Skip If Commit Contains)
+      on:
+        push:
+      jobs:
+        bump-version:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v2
+            - run: echo "Bump Version (Skip If Commit Contains)"
+            - run: env
+            - id: version-bump
+              uses: ./action
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                skip-if-commit-contains: dependabot
+    tests:
+      - message: patch
+        expected:
+          version: 1.0.1
+      - message: patch (Dependabot)
+        expected:
+          skipTagCheck: true
+          version: 1.0.0
+      - message: minor
+        expected:
+          version: 1.1.0
+      - message: minor (Dependabot)
+        expected:
+          skipTagCheck: true
+          version: 1.0.0
+      - message: major
+        expected:
+          version: 2.0.0
+      - message: major (Dependabot)
+        expected:
+          skipTagCheck: true
+          version: 1.0.0
+      - message: pre-alpha
+        expected:
+          version: 1.0.1-alpha.0
+      - message: pre-alpha (Dependabot)
+        expected:
+          skipTagCheck: true
+          version: 1.0.0
   - name: null-default
     yaml:
       name: Bump Version (Default="Minor")


### PR DESCRIPTION
Added `skip-if-commit-contains` parameter to be able to avoid version bump if the commit message contains the specified (case-insensitive) text.

Minor version update.